### PR TITLE
Support CMPSB

### DIFF
--- a/cpu.py
+++ b/cpu.py
@@ -225,10 +225,7 @@ class Register64(object):
     def setX(self, val):
         assert isinstance(val, (int,long)) or (isinstance(val, BitVec) and val.size == 16)
         val = EXTRACT(val, 0,16)
-        if isinstance(val, BitVec):
-            self._RX = ZEXTEND(val,64)
-        else:
-            self._RX = self._RX & 0xFFFFFFFFFFFF0000 | ZEXTEND(val,64)
+        self._RX = self._RX & 0xFFFFFFFFFFFF0000 | ZEXTEND(val,64)
         self._cache = { 'X': val}
         return val
     def getX(self):
@@ -237,7 +234,6 @@ class Register64(object):
     def setH(self, val):
         assert isinstance(val, (int,long)) or (isinstance(val, BitVec) and val.size == 8)
         val = EXTRACT(val, 0,8)
-        #TODO: handle BitVec val
         self._RX = self._RX & 0xFFFFFFFFFFFF00FF | ZEXTEND(val,64) << 8
         self._cache = {'H': val, 'L': self.getL()}
         return val
@@ -247,10 +243,7 @@ class Register64(object):
     def setL(self, val):
         assert isinstance(val, (int,long)) or (isinstance(val, BitVec) and val.size == 8)
         val = EXTRACT(val, 0,8)
-        if isinstance(val, BitVec):
-            self._RX = ZEXTEND(val,64)
-        else:
-            self._RX = self._RX & 0xFFFFFFFFFFFFFF00 | ZEXTEND(val,64)
+        self._RX = self._RX & 0xFFFFFFFFFFFFFF00 | ZEXTEND(val,64)
         self._cache = {'L': val, 'H': self.getH()}
         return val
     def getL(self):

--- a/cpu.py
+++ b/cpu.py
@@ -128,25 +128,24 @@ def rep(old_method):
                 cpu.PC = cpu.PC + cpu.instruction.size
             #Repeat!
             else:
-	        first = True
-		previous_ZF = False
-		previous_CF = False
+                first = True
+                previous_ZF = False
+                previous_CF = False
                 while count > 0:
                     count -= 1
                     cpu.setRegister(counter_name, count)
                     old_method(cpu, *args, **kw_args)
-                    if cpu.instruction.mnemonic.upper().split(' ')[0] == 'REPE':
-			if first:
-			    previous_ZF = cpu.ZF
-			    previous_CF = cpu.CF
-			    first = False
-			else:
+                    if first:
+                        previous_ZF = cpu.ZF
+                        previous_CF = cpu.CF
+                        first = False
+                    else:
                             previous_ZF = AND(cpu.ZF, previous_ZF)
                             previous_CF = AND(cpu.CF, previous_CF)
-		cpu.ZF = previous_ZF
-		cpu.CF = previous_CF
-		cpu.IF = False
-		cpu.PC += cpu.instruction.size
+                cpu.ZF = previous_ZF
+                cpu.CF = previous_CF
+                cpu.IF = False
+                cpu.PC += cpu.instruction.size
         else:
             cpu.PC += cpu.instruction.size
             old_method(cpu, *args,**kw_args)

--- a/cpu.py
+++ b/cpu.py
@@ -139,8 +139,7 @@ def rep(old_method):
                     cpu.ZF = AND(cpu.ZF, previous_ZF)
                     cpu.CF = AND(cpu.CF, previous_CF)
 
-                if count == 0:
-                    cpu.PC += cpu.instruction.size
+                cpu.PC = ITE(cpu.AddressSize, count != 0, cpu.PC, cpu.PC + cpu.instruction.size)
             #Advance!
             else:
                 cpu.PC = cpu.PC + cpu.instruction.size

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,7 +1,7 @@
 all: toy001-nostdlib  toy002-libc  toy003-sindex  toy004-strcmp  toy005-arguments
 
 clean:
-		rm -rf toy001-nostdlib toy002-libc
+		rm -rf toy001-nostdlib toy002-libc toy003-sindex toy004-strcmp
 
 toy001-nostdlib:
 		gcc -fno-builtin -static -nostdlib -m32  -fomit-frame-pointer  toy001-nostdlib.c  -o toy001-nostdlib
@@ -10,10 +10,10 @@ toy002-libc:
 		gcc toy002-libc.c -static -o toy002-libc
 
 toy003-sindex:
-		gcc toy003-sindex.c -o toy003-sindex
+		gcc toy003-sindex.c -static -o toy003-sindex
 
 toy004-strcmp:
-		gcc toy004-strcmp.c -o toy004-strcmp
+		gcc toy004-strcmp.c -static -o toy004-strcmp
 
 toy005-arguments:
 		gcc -O0 -m32 toy005-arguments.c  -o toy005-arguments


### PR DESCRIPTION
Support CMPSB

I targeted following scenario (toy4 strcmp)
```asm
  4011e4:       f3 a6                   repz cmpsb %es:(%rdi),%ds:(%rsi)
  4011e6:       0f 97 c2                seta   %dl
  4011e9:       0f 92 c0                setb   %al
  4011ec:       89 d1                   mov    %edx,%ecx
  4011ee:       28 c1                   sub    %al,%cl
  4011f0:       89 c8                   mov    %ecx,%eax
  4011f2:       0f be c0                movsbl %al,%eax
  4011f5:       85 c0                   test   %eax,%eax
  4011f7:       75 0c                   jne    401205 <main+0xa1>
  4011f9:       bf cb 65 49 00          mov    $0x4965cb,%edi
  4011fe:       e8 fd 0e 00 00          callq  402100 <_IO_puts>
```

```
$ python system.py --sym stdin examples/toy004-strcmp
...
...
...
Symbolic PC found, possible detinations are:  ['4011f9', '401205']
	Saving state state_00000000004011f9_6883.pkl
Program Finnished correctly
stdin:  '\x00\xc0\xf04X@\x804\n'
	 Loading state  state_00000000004011f9_6883.pkl
Program Finnished correctly
stdin:  'ZARAZA\x00A\n'
Results dumped in  ./pse_D8AtZZ
8733 2222.13740458
```

Please tell me if it does not work.
