### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ The commandline gives you a somehow confusing help. :)
    -h, --help           show this help message and exit
    --worspace WORSPACE  A folder name fpor temporaries and results. (default pse_?????)
    --sym SYM            Consider a filename as symbolic
-   --stdin STDIN        A filename to pass as standar stdin (default: stdin)
-   --stdout STDOUT      A filename to pass as standar stdout (default: stdout)
-   --stderr STDERR      A filename to pass as standar stderr (default: stderr)
+   --stdin STDIN        A filename to pass as standard stdin (default: stdin)
+   --stdout STDOUT      A filename to pass as standard stdout (default: stdout)
+   --stderr STDERR      A filename to pass as standard stderr (default: stderr)
    --env ENV            A environment variable to pass to the program (ex. VAR=VALUE)
 ```
 
@@ -152,7 +152,7 @@ symbolic (its '+' will be free 8bit variables) with --sym 'stdin', like this:
 
 ``` $ python system.py --sym stdin examples/toy002-libc```
 
-The quick and dirty command line tool will generate somthing like this..
+The quick and dirty command line tool will generate something like this..
 ```
  $ python system.py  --sym stdin examples/toy002-libc
  [+] Running examples/toy002-libc

--- a/cpu.py
+++ b/cpu.py
@@ -5421,7 +5421,7 @@ def putcache(cache_name):
                     else:
                         p+=1
                 return value
-            #invalidate any overlaping cached value #todo extract remaining valid bits
+            #invalidate any overlapping cached value #todo extract remaining valid bits
             p = where
             while p <= where+size/8:
                 if p in used:
@@ -5461,7 +5461,7 @@ def getcache(cache_name):
                         return EXTRACT(cached_expr,offset,size) #(cached_expr>>offset)&((1<<size)-1)
             value = get(obj, where, size,**kw_args)
             if isconcrete(where):
-                #invalidate any overlaping cached value #todo extract remaining valid bits
+                #invalidate any overlapping cached value #todo extract remaining valid bits
                 p = where
                 while p <= where+size/8:
                     if p in used:

--- a/examples/toy002-libc.c
+++ b/examples/toy002-libc.c
@@ -1,5 +1,5 @@
 /* Minimal toy example with input output using libc
- * Symbolic values are read from stdin using standar libc calls. 
+ * Symbolic values are read from stdin using standard libc calls. 
  *    
  * Compile with :
  *   $ gcc toy002-libc.c -o toy002-libc

--- a/linux.py
+++ b/linux.py
@@ -921,7 +921,7 @@ class Linux(object):
         @param cpu: current CPU.
         @param start: the starting address to change the permissions.
         @param size: the size of the portion of memory to change the permissions.
-        @param prot: the new acces premission for the memory.
+        @param prot: the new acces permission for the memory.
         @return: C{0} on success.
         '''
         perms = ['   ', 'r  ',' w ','rw ','  x','r x', ' wx','rwx'][prot&7]
@@ -1244,7 +1244,7 @@ class Linux(object):
 
     def execute(self):
         """
-        Execute one cpu instruction in the current thread (only one suported).
+        Execute one cpu instruction in the current thread (only one supported).
         Intruction may result in a syscall.
 
         @rtype: bool

--- a/memory.py
+++ b/memory.py
@@ -787,7 +787,7 @@ class Memory(object):
         """
         start = self._floor(start)
         size = self._ceil(size-1)
-        #select all mappings that have at least 1 byte unmaped
+        #select all mappings that have at least 1 byte unmapped
         affected = set()
         p = self._page(start)
         while p < self._page(self._ceil(start+size)):
@@ -849,7 +849,7 @@ class Memory(object):
             #remove m from the maps set
             self.maps.remove(m)
 
-            #unmap the range from m posibly generating 0, 1 or 2 new maps
+            #unmap the range from m possibly generating 0, 1 or 2 new maps
             new_maps += m.mprotect(start, size, perms)
 
         #reattach the newly generated maps (it may be none)
@@ -1041,7 +1041,7 @@ class SMemory(Memory):
         @param addr: the address to put a concrete or symbolic content
         @param data: the content to put in C{addr}
         
-        @todo: if addr is Readable/Executable? Double checked when accesing parent class!
+        @todo: if addr is Readable/Executable? Double checked when accessing parent class!
         @todo: Instead of concretizing all possible values in range raise exception
                and make executor for arr on each mapped page
 
@@ -1080,7 +1080,7 @@ class SMemory(Memory):
         @param addr: the address to obtain its content
         @return: a character or a symbol stored in C{addr}
         
-        @todo:  if addr is Readable/Executable? Double checked when accesing parebnt class!!!
+        @todo:  if addr is Readable/Executable? Double checked when accessing parebnt class!!!
         """
         if issymbolic(addr):
             logger.debug("Read from symbolic address %s", str(addr).replace("\n",""))

--- a/smtlib.py
+++ b/smtlib.py
@@ -486,7 +486,7 @@ class Solver(object):
             This is implemented using an external native solver via a subprocess.
             Everytime a new symbol or assertion is added a smtlibv2 command is 
             sent to the solver.
-            The actual state is also mantained in memory to be able to save and
+            The actual state is also maintained in memory to be able to save and
             restore the state. 
             The analisys may be saved to disk and continued after a while or 
             forked in memory or even sent over the network.
@@ -606,7 +606,7 @@ class Solver(object):
     def max(self, X, M=10000):
         ''' Iterativelly finds the maximum value for a symbol.
             @param X: a symbol or expression
-            @param M: maximun number of iterations allowed
+            @param M: maximum number of iterations allowed
         '''
         assert self.check() == 'sat'
         assert type(X) is BitVec
@@ -637,7 +637,7 @@ class Solver(object):
     def min(self, X, M=10000):
         ''' Iterativelly finds the minimum value for a symbol.
             @param X: a symbol or expression
-            @param M: maximun number of iterations allowed
+            @param M: maximum number of iterations allowed
         '''
         assert self.check() == 'sat'
         assert type(X) is BitVec

--- a/system.py
+++ b/system.py
@@ -283,7 +283,7 @@ if __name__ == '__main__':
             except SymbolicPCException, e:
                 #if PC gets "tainted" with symbols do stuff
                 assert issymbolic(current_state.cpu.PC)
-                #get all possible PC destinations (raise if more tahn 100 options)
+                #get all possible PC destinations (raise if more than 100 options)
                 vals = list(current_state.solver.getallvalues(current_state.cpu.PC, maxcnt = 100))
                 print "Symbolic PC found, possible detinations are: ", ["%x"%x for x in vals]
 
@@ -307,7 +307,7 @@ if __name__ == '__main__':
                 current_state.solver.add(current_pc == new_pc)
                 current_state.cpu.PC = new_pc
 
-                #Try to do some symplifications to shrink symbolic footprint
+                #Try to do some simplifications to shrink symbolic footprint
                 try :
                     bvals = []
                     current_state.solver.push()


### PR DESCRIPTION
There are small typos in:
- README.md
- cpu.py
- examples/toy002-libc.c
- linux.py
- memory.py
- smtlib.py
- system.py

Fixes:
- Should read `standard` rather than `standar`.
- Should read `overlapping` rather than `overlaping`.
- Should read `maximum` rather than `maximun`.
- Should read `accessing` rather than `accesing`.
- Should read `unmapped` rather than `unmaped`.
- Should read `than` rather than `tahn`.
- Should read `supported` rather than `suported`.
- Should read `something` rather than `somthing`.
- Should read `simplifications` rather than `symplifications`.
- Should read `possibly` rather than `posibly`.
- Should read `permission` rather than `premission`.
- Should read `maintained` rather than `mantained`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md